### PR TITLE
Handle number input

### DIFF
--- a/src/pegthing/core.clj
+++ b/src/pegthing/core.clj
@@ -199,7 +199,9 @@
      (let [input (clojure.string/trim (read-line))]
        (if (empty? input)
          default
-         (clojure.string/lower-case input)))))
+         (cond
+           (re-matches #"\d+" input) (read-string input)
+           :else (clojure.string/lower-case input))))))
 
 (defn characters-as-strings
   "Given a string, return a collection consisting of each indivisual


### PR DESCRIPTION
Can't enter board size. It's only allow to play with 5 rows at the moment.

I feel that my change is a quite verbose so feel free to discard this change if you have a better one.

```
$ lein run
Get ready to play peg thing!
How many rows? [5]
6
Exception in thread "main" java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
	at clojure.lang.Numbers.isPos(Numbers.java:94)
	at clojure.core$take$fn__4232.invoke(core.clj:2553)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:60)
	at clojure.lang.LazySeq.next(LazySeq.java:89)
	at clojure.lang.RT.next(RT.java:598)
	at clojure.core$next.invoke(core.clj:64)
	at clojure.core$last.invoke(core.clj:251)
	at pegthing.core$row_tri.invoke(core.clj:27)
	at pegthing.core$new_board.invoke(core.clj:82)
	at pegthing.core$prompt_rows.invoke(core.clj:252)
	at pegthing.core$_main.doInvoke(core.clj:258)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.Var.invoke(Var.java:411)
	at user$eval15$fn__17.invoke(form-init3030153208035691129.clj:1)
	at user$eval15.invoke(form-init3030153208035691129.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:6619)
	at clojure.lang.Compiler.eval(Compiler.java:6609)
	at clojure.lang.Compiler.load(Compiler.java:7064)
	at clojure.lang.Compiler.loadFile(Compiler.java:7020)
	at clojure.main$load_script.invoke(main.clj:294)
	at clojure.main$init_opt.invoke(main.clj:299)
	at clojure.main$initialize.invoke(main.clj:327)
	at clojure.main$null_opt.invoke(main.clj:362)
	at clojure.main$main.doInvoke(main.clj:440)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at clojure.lang.Var.invoke(Var.java:419)
	at clojure.lang.AFn.applyToHelper(AFn.java:163)
	at clojure.lang.Var.applyTo(Var.java:532)
	at clojure.main.main(main.java:37)
```

Thanks for writing this book.