### PR TITLE
Fixed program crashing when provided no input

### DIFF
--- a/src/pegthing/core.clj
+++ b/src/pegthing/core.clj
@@ -194,7 +194,7 @@
 
 (defn get-input
   "Waits for user to enter text and hit enter, then cleans the input"
-  ([] (get-input nil))
+  ([] (get-input ""))
   ([default]
      (let [input (clojure.string/trim (read-line))]
        (if (empty? input)


### PR DESCRIPTION
Previously, program would throw a NullPointerException if I pressed return in place of two pegs' letters. Now it shows "invalid move", as it should in the first place.